### PR TITLE
PCQ-342: Add readiness check and upgrade node chart

### DIFF
--- a/app/healthcheck.js
+++ b/app/healthcheck.js
@@ -13,7 +13,6 @@ const gitProperties = require('git.properties');
 const gitCommitId = gitProperties.git.commit.id;
 const gitRevision = process.env.GIT_REVISION;
 
-const statusComment = 'Please disregard \'status\' and take \'actualStatus\' as the absolute truth.';
 const checks = {
     'pcq-backend': healthcheck.web(`${config.services.pcqBackend.url}/health`, {
         callback: (err, res) => {
@@ -22,25 +21,29 @@ const checks = {
                 logger.warn('pcq-backend is DOWN');
                 logger.warn(err);
             }
-            return healthcheck.up({actualStatus: status, comment: statusComment});
+            return status === 'UP' ? healthcheck.up() : healthcheck.down();
         },
         timeout: 10000,
         deadline: 20000
     })
 };
+const readinessChecks = {};
 if (sessionStore.constructor.name === 'RedisStore') {
-    checks.redis = healthcheck.raw(() => {
+    const redisHealthcheck = healthcheck.raw(() => {
         const healthy = sessionStore.client.status === 'ready';
         if (!healthy) {
             logger.info('redis is DOWN');
         }
         return healthy ? healthcheck.up() : healthcheck.down();
     });
+    checks.redis = redisHealthcheck;
+    readinessChecks.redis = redisHealthcheck;
 }
 
 const setup = app => {
     healthcheck.addTo(app, {
         checks: checks,
+        readinessChecks: readinessChecks,
         buildInfo: {
             name: config.service.name,
             host: os.hostname(),

--- a/app/healthcheck.js
+++ b/app/healthcheck.js
@@ -13,15 +13,18 @@ const gitProperties = require('git.properties');
 const gitCommitId = gitProperties.git.commit.id;
 const gitRevision = process.env.GIT_REVISION;
 
+const statusComment = '\'actualStatus\' is the same as \'status\'. It is there for backwards compatibility. Please disregard.';
 const checks = {
     'pcq-backend': healthcheck.web(`${config.services.pcqBackend.url}/health`, {
         callback: (err, res) => {
-            const status = err ? 'DOWN' : res.body.status;
+            const status = err ? 'DOWN' : res.body.status || 'DOWN';
             if (status === 'DOWN') {
                 logger.warn('pcq-backend is DOWN');
                 logger.warn(err);
             }
-            return status === 'UP' ? healthcheck.up() : healthcheck.down();
+            // DEPRECATED: To be removed after all services stop depending on 'actualStatus'
+            const options = {actualStatus: status, comment: statusComment};
+            return status === 'UP' ? healthcheck.up(options) : healthcheck.down(options);
         },
         timeout: 10000,
         deadline: 20000

--- a/app/registerIncomingService.js
+++ b/app/registerIncomingService.js
@@ -20,7 +20,7 @@ router.get('/service-endpoint', (req, res) => {
     asyncFetch
         .fetch('http://localhost:4000/health', {}, fetchRes => fetchRes.json())
         .then(json => {
-            if (json['pcq-backend'] && json['pcq-backend'].actualStatus === 'UP') {
+            if (json['pcq-backend'] && json['pcq-backend'].status === 'UP') {
                 // Reset the session on registering a new incoming service
                 req.session.regenerate(() => {
                     initSession(req, res);

--- a/charts/pcq-frontend/Chart.yaml
+++ b/charts/pcq-frontend/Chart.yaml
@@ -1,8 +1,8 @@
-apiVersion: v1
-description: A Helm chart for the HMCTS PCQ product
+apiVersion: v2
 name: pcq-frontend
+description: A Helm chart for the HMCTS PCQ product
 home: https://github.com/hmcts/pcq-frontend
-version: 1.0.31
+version: 1.1.0
 maintainers:
   - name: HMCTS PCQ Team
     email: pcq-action-group@HMCTS.NET

--- a/charts/pcq-frontend/requirements.yaml
+++ b/charts/pcq-frontend/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: nodejs
-    version: 1.10.0
+    version: 2.0.1
     repository: '@hmctspublic'
   - name: redis
     version: 10.5.7

--- a/charts/pcq-frontend/values.yaml
+++ b/charts/pcq-frontend/values.yaml
@@ -12,7 +12,7 @@ nodejs:
     REDIS_USE_TLS: true
     REDIS_PORT: 6380
     REDIS_HOST: pcq-frontend-redis-cache-{{ .Values.global.environment }}.redis.cache.windows.net
-    PCQ_BACKEND_URL: http://pcq-backend-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    PCQ_BACKEND_URL: http://pcq-backend-pr-108.service.core-compute-preview.internal
     REFORM_ENVIRONMENT: '{{ .Values.global.environment }}'
   image: hmctspublic.azurecr.io/pcq/frontend:latest
   ingressHost: pcq.{{ .Values.global.environment }}.platform.hmcts.net

--- a/charts/pcq-frontend/values.yaml
+++ b/charts/pcq-frontend/values.yaml
@@ -12,7 +12,7 @@ nodejs:
     REDIS_USE_TLS: true
     REDIS_PORT: 6380
     REDIS_HOST: pcq-frontend-redis-cache-{{ .Values.global.environment }}.redis.cache.windows.net
-    PCQ_BACKEND_URL: http://pcq-backend-pr-108.service.core-compute-preview.internal
+    PCQ_BACKEND_URL: http://pcq-backend-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     REFORM_ENVIRONMENT: '{{ .Values.global.environment }}'
   image: hmctspublic.azurecr.io/pcq/frontend:latest
   ingressHost: pcq.{{ .Values.global.environment }}.platform.hmcts.net

--- a/charts/pcq-frontend/values.yaml
+++ b/charts/pcq-frontend/values.yaml
@@ -12,7 +12,7 @@ nodejs:
     REDIS_USE_TLS: true
     REDIS_PORT: 6380
     REDIS_HOST: pcq-frontend-redis-cache-{{ .Values.global.environment }}.redis.cache.windows.net
-    PCQ_BACKEND_URL: http://pcq-backend-pr-108.service.core-compute-preview.internal
+    PCQ_BACKEND_URL: http://pcq-backend-pr-112.service.core-compute-preview.internal
     REFORM_ENVIRONMENT: '{{ .Values.global.environment }}'
   image: hmctspublic.azurecr.io/pcq/frontend:latest
   ingressHost: pcq.{{ .Values.global.environment }}.platform.hmcts.net

--- a/charts/pcq-frontend/values.yaml
+++ b/charts/pcq-frontend/values.yaml
@@ -12,7 +12,7 @@ nodejs:
     REDIS_USE_TLS: true
     REDIS_PORT: 6380
     REDIS_HOST: pcq-frontend-redis-cache-{{ .Values.global.environment }}.redis.cache.windows.net
-    PCQ_BACKEND_URL: http://pcq-backend-pr-112.service.core-compute-preview.internal
+    PCQ_BACKEND_URL: http://pcq-backend-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     REFORM_ENVIRONMENT: '{{ .Values.global.environment }}'
   image: hmctspublic.azurecr.io/pcq/frontend:latest
   ingressHost: pcq.{{ .Values.global.environment }}.platform.hmcts.net

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint"
   ],
   "dependencies": {
-    "@hmcts/nodejs-healthcheck": "^1.6.0",
+    "@hmcts/nodejs-healthcheck": "^1.7.0",
     "@hmcts/nodejs-logging": "^3.0.0",
     "@hmcts/properties-volume": "^0.0.9",
     "ajv": "^4.11.8",

--- a/test/unit/middleware/testRegisterIncomingService.js
+++ b/test/unit/middleware/testRegisterIncomingService.js
@@ -141,7 +141,7 @@ describe('registerIncomingService', () => {
                 .get('/health')
                 .reply(
                     200,
-                    {'pcq-backend': {'actualStatus': 'UP'}}
+                    {'pcq-backend': {'status': 'UP'}}
                 );
             const server = app.init();
             const agent = request.agent(server.app);

--- a/test/unit/testHealthcheck.js
+++ b/test/unit/testHealthcheck.js
@@ -42,6 +42,33 @@ describe('Healthcheck', () => {
             const server = app.init();
             const agent = request.agent(server.app);
             agent.get('/health')
+                .expect(500)
+                .end((err, res) => {
+                    server.http.close();
+                    if (err) {
+                        throw err;
+                    }
+                    expect(res.body).to.have.property('status').and.equal('DOWN');
+                    expect(res.body).to.have.property('pcq-backend').and.deep.equal({
+                        status: 'DOWN'
+                    });
+                    expect(res.body).to.have.property('buildInfo');
+                    done();
+                });
+        });
+    });
+
+    describe('/health/readiness endpoint', () => {
+        it('should return the readiness status', (done) => {
+            nock(config.services.pcqBackend.url)
+                .get('/health')
+                .reply(
+                    200,
+                    {'status': 'UP'}
+                );
+            const server = app.init();
+            const agent = request.agent(server.app);
+            agent.get('/health/readiness')
                 .expect(200)
                 .end((err, res) => {
                     server.http.close();
@@ -49,12 +76,28 @@ describe('Healthcheck', () => {
                         throw err;
                     }
                     expect(res.body).to.have.property('status').and.equal('UP');
-                    expect(res.body).to.have.property('pcq-backend').and.deep.equal({
-                        actualStatus: 'DOWN',
-                        comment: 'Please disregard \'status\' and take \'actualStatus\' as the absolute truth.',
-                        status: 'UP'
-                    });
-                    expect(res.body).to.have.property('buildInfo');
+                    done();
+                });
+        });
+
+        it('should return UP status if backend is down', (done) => {
+            nock(config.services.pcqBackend.url)
+                .get('/health')
+                .reply(
+                    500,
+                    {'status': 'DOWN'}
+                );
+
+            const server = app.init();
+            const agent = request.agent(server.app);
+            agent.get('/health/readiness')
+                .expect(200)
+                .end((err, res) => {
+                    server.http.close();
+                    if (err) {
+                        throw err;
+                    }
+                    expect(res.body).to.have.property('status').and.equal('UP');
                     done();
                 });
         });

--- a/test/unit/testHealthcheck.js
+++ b/test/unit/testHealthcheck.js
@@ -50,7 +50,9 @@ describe('Healthcheck', () => {
                     }
                     expect(res.body).to.have.property('status').and.equal('DOWN');
                     expect(res.body).to.have.property('pcq-backend').and.deep.equal({
-                        status: 'DOWN'
+                        'actualStatus': 'DOWN',
+                        'comment': '\'actualStatus\' is the same as \'status\'. It is there for backwards compatibility. Please disregard.',
+                        'status': 'DOWN'
                     });
                     expect(res.body).to.have.property('buildInfo');
                     done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,10 +110,10 @@
     lodash.mergewith "^4.6.2"
     webdriverio "^5.15.2"
 
-"@hmcts/nodejs-healthcheck@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@hmcts/nodejs-healthcheck/-/nodejs-healthcheck-1.6.0.tgz#ecc2002f2617b207c0cc48c6c11198e53fc8bb68"
-  integrity sha512-i9PsSbbZoI7fghnVNi6sWnwvWnJdTtEz0ytBuCogpLOVQLpeMh1FTub79AxAxIdJIvpS/s6lyGg5U+gk2mdhxA==
+"@hmcts/nodejs-healthcheck@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@hmcts/nodejs-healthcheck/-/nodejs-healthcheck-1.7.0.tgz#82b496d8f23f32d9670564ada3e773a55f544721"
+  integrity sha512-98hPAZdRkHbFkr35HXG3Pr03C6RDM7GKDSfIxm+AZVauaxZ0L02v0cv2pq4ueee6mD+rctQ4aczg1juYfkOHEQ==
   dependencies:
     "@hmcts/nodejs-logging" "^3.0.1"
     js-yaml "^3.8.4"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PCQ-342

### Change description ###

Reopened https://github.com/hmcts/pcq-frontend/pull/97

- Upgraded nodejs healthcheck to 1.7.0 and added readiness checks.
- Upgraded nodejs chart version to 2.0.1
- Upgraded chart api version to v2
- 'actualStatus' for backend has been left in for backwards compatibility.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
