### PR TITLE
PCQ-621: Use CMC for tests using tokens

### DIFF
--- a/test/unit/middleware/testInvoker.js
+++ b/test/unit/middleware/testInvoker.js
@@ -65,7 +65,7 @@ describe('Invoker', () => {
             const genToken = invoker.__get__('genToken');
             const req = {
                 query: {
-                    serviceId: 'PROBATE',
+                    serviceId: 'CMC',
                     actor: 'b',
                     ccdCaseId: 'd',
                     pcqId: 'c',
@@ -80,9 +80,9 @@ describe('Invoker', () => {
 
             genToken(req, res);
             const token = res.json.args[0][0].token;
-            expect(token).to.equal('35c2d8724dd2660d503314e9e641bfec60450b184eaf5ec42703f8cc0a8981e192493b6d5' +
-                '3a3ca147a44d3ac917cb5ad5c637ddee2b478db196ec0545f5342f79cc85f51074d5e4110653d63d1d272dcfd17a7e5a84' +
-                '58cce7ca21ba1806a5effc8379a1da531332ab52cd52d69e2a0f8');
+            expect(token).to.equal('3b74573af3cf7403d07f8f9b58e8fbfa94ee6020841b2ca867aa2a8ccc3a7c402ecd95ba6a' +
+                '8a83519d908f5915769d16e471e29f3cabb28b5b2c970c0227365d0d952adb5443c37121e601c31847cca4063fd34245e1f' +
+                'a351260956a64b496db9d32145be475847a486a08a397746b64');
 
             done();
         });

--- a/test/unit/middleware/testRegisterIncomingService.js
+++ b/test/unit/middleware/testRegisterIncomingService.js
@@ -90,15 +90,15 @@ describe('registerIncomingService', () => {
         it('should assign a valid JWT token to the session', (done) => {
             const req = {
                 query: {
-                    serviceId: 'PROBATE',
-                    actor: 'APPLICANT',
+                    serviceId: 'CMC',
+                    actor: 'CLAIMANT',
                     pcqId: '78e69022-2468-4370-a88e-bea2a80fa51f',
                     partyId: 'applicant@email.com',
                     returnUrl: 'invoking-service-return-url/',
-                    token: '35c2d8724dd2660d503314e9e641bfec60450b184eaf5ec42703f8cc0a8981e156400899e8923bb878b4b62c6417' +
-                        'de175468ce6e7aab65af57b7ec70139ffe48983550ed3a59e5b0a5b0038327a3c0e1c543da6e0da50a716781b61faf0' +
-                        '49a97bf238f80990cb923917b3c0c29ba1f7e802dd00d9d24fcbceb913332827863ebb07e5e3ce28120afab3d492494' +
-                        'ee93297da5fe8dea2f262a5a5b8af95520f143464289569a95d5dd2da55b8da0869c73'
+                    token: '3b74573af3cf7403d07f8f9b58e8fbfae5b41a389469858da85f94caf089a4dd3bdfa79bfd347275329900c5' +
+                        '4e06eee027383c3b2cfe5fb0258033e72bd8cc82334d69d2ac2d11208cd825b52b1a9b77b2dd48e344018c4cf7f' +
+                        'fc08297beb6cb6f344a70fe9bcd21d0cf1af6b1d69858442853ce245b66ce086818e3faed638d38db4036f396db' +
+                        '28f20bd333db5a2d9207671fc69c551d112fc23fd9c7f9eae41cbecb9b2bd37457268c6f14e751507c'
                 },
                 session: {
                     form: {}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PCQ-621

### Change description ###

- Use CMC for tests using tokens. This is because the mutation tests have the probate AAT token key loaded in for the nightly tests. The unit tests are expecting the default key. Switching the CMC ensures the default key is used for these token tests. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
