### PR TITLE
Update functional tests to point to aat

### DIFF
--- a/test/end-to-end/helpers/TestConfigurator.js
+++ b/test/end-to-end/helpers/TestConfigurator.js
@@ -17,7 +17,7 @@ class TestConfigurator {
 
     getUserData(pcqid) {
         request({
-            url: `http://pcq-backend-staging.service.core-compute-aat.internal/pcq/backend/getAnswer/${pcqid}`,
+            url: `http://pcq-backend-aat.service.core-compute-aat.internal/pcq/backend/getAnswer/${pcqid}`,
             method: 'GET',
             proxy: this.testProxy,
             headers: {'content-type': 'application/json'},


### PR DESCRIPTION
### Change description ###

A jenkins pipeline update was made to destroy the staging environment once the pipline has completed. We now need to point the functional tests to the backend AAT rather than staging.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
