### PR TITLE
PCQ-723: Move redis repo to bitnami

### DIFF
--- a/charts/pcq-frontend/Chart.yaml
+++ b/charts/pcq-frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pcq-frontend
 description: A Helm chart for the HMCTS PCQ product
 home: https://github.com/hmcts/pcq-frontend
-version: 1.2.5
+version: 1.2.6
 maintainers:
   - name: HMCTS PCQ Team
     email: pcq-action-group@HMCTS.NET
@@ -12,5 +12,5 @@ dependencies:
     repository: '@hmctspublic'
   - name: redis
     version: 10.5.7
-    repository: '@stable'
+    repository: 'https://charts.bitnami.com/bitnami'
     condition: redis.enabled

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protected-characteristics-frontend",
   "description": "Protected Characteristics web app",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "engines": {
     "node": ">=12.15.0"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PCQ-723

### Change description ###

Move redis repo to bitnami from stable. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
