### PR TITLE
PCQ-891: Move step loading to boot time to prevent disk loading errors

### DIFF
--- a/app/core/initSteps.js
+++ b/app/core/initSteps.js
@@ -32,17 +32,17 @@ const initStep = (filePath, language) => {
 
 const initSteps = (stepLocations, language = 'en') => {
     initI18Next();
-    stepLocations.forEach((location) => {
-        const calculatePath = sPath => {
-            if ((/index.js$/).test(sPath)) {
-                const step = initStep(sPath, language);
-                steps[step.name] = step;
-                return true;
-            }
-            return false;
-        };
+    const calculatePath = sPath => {
+        if ((/index.js$/).test(sPath)) {
+            const step = initStep(sPath, language);
+            steps[step.name] = step;
+            return true;
+        }
+        return false;
+    };
+    for (const location of stepLocations) {
         requireDir(module, location, {include: calculatePath});
-    });
+    }
 
     return steps;
 };

--- a/app/routes.js
+++ b/app/routes.js
@@ -29,8 +29,13 @@ router.get('/', (req, res) => {
 
 router.post('/opt-out', optOut);
 
+const allSteps = {
+    'en': initSteps([`${__dirname}/steps/ui`], 'en'),
+    'cy': initSteps([`${__dirname}/steps/ui`], 'cy')
+};
+
 router.use((req, res, next) => {
-    const steps = initSteps([`${__dirname}/steps/ui`], req.session.language);
+    const steps = allSteps[req.session.language];
 
     Object.entries(steps).forEach(([, step]) => {
         router.get(step.constructor.getUrl(), step.runner().GET(step));


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PCQ-891

### Change description ###

Move step loading to boot time to prevent disk loading errors. These errors seem to be caused by the disk not available momentarily and thus an ENOENT error is thrown. This is seen as a 500 error to the user. By moving the step loading to boot time, those files will not need to be read again after booting.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
