### PR TITLE
PCQ-1074 node-saas tar vulnerability fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "trim-newlines": "^3.0.1",
     "normalize-url": "^4.5.1",
     "node-gyp": "^8.1.0",
-    "path-parse": "^1.0.7"
+    "path-parse": "^1.0.7",
+    "tar": "^6.1.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4761,7 +4761,7 @@ make-fetch-happen@^8.0.14:
 
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
 
 md5@^2.1.0:
@@ -7145,10 +7145,10 @@ tar-stream@^2.0.0, tar-stream@^2.1.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^6.0.2, tar@^6.1.0:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
-  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
+tar@^6.0.2, tar@^6.1.0, tar@^6.1.7:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-1074


### Change description ###
tar has been added and upgraded to 6.1.7 to fix vulnerability .


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
