### PR TITLE
PCQ-1238 Fix Redis connection timeout issues

### DIFF
--- a/app/components/utils.js
+++ b/app/components/utils.js
@@ -18,6 +18,15 @@ exports.getStore = (redisConfig, session) => {
         };
         const redisOptions = redisConfig.useTLS === 'true' ? tlsOptions : {};
         const client = new Redis(redisConfig.port, redisConfig.host, redisOptions);
+
+        // Azure Cache for Redis has issues with a 10 minute connection idle timeout, the recommendation is to keep the connection alive
+        // https://gist.github.com/JonCole/925630df72be1351b21440625ff2671f#file-redis-bestpractices-node-js-md
+        client.on('ready', () => {
+            setInterval(() => {
+                client.ping();
+            }, 60000); // 60s
+        });
+
         return new RedisStore({client});
     }
     const MemoryStore = require('express-session').MemoryStore;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PCQ-1238

### Change description ###

Add 60s continuous ping to the redis server to ensure the Azure Redis cache doesn't timeout the connection.
https://gist.github.com/JonCole/925630df72be1351b21440625ff2671f#file-redis-bestpractices-node-js-md

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
