### PR TITLE
Upgrade nodejs chart v to 2.4.3

### DIFF
--- a/charts/pcq-frontend/Chart.yaml
+++ b/charts/pcq-frontend/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: pcq-frontend
 description: A Helm chart for the HMCTS PCQ product
 home: https://github.com/hmcts/pcq-frontend
-version: 1.2.13
+version: 1.2.14
 maintainers:
   - name: HMCTS PCQ Team
     email: pcq-action-group@HMCTS.NET
 dependencies:
   - name: nodejs
-    version: 2.4.0
+    version: 2.4.3
     repository: '@hmctspublic'
   - name: redis
     version: 10.5.7


### PR DESCRIPTION
### Change description ###

Upgrade nodejs chart version to 2.4.3. Current version 2.4.0 is deprecated and will not pass pipeline.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
