### PR TITLE
PCQ-1420-security-scan-fail-cookie_bundle_v1

### DIFF
--- a/audit.json
+++ b/audit.json
@@ -52,6 +52,7 @@
   "10104_User Agent Fuzzer_https://pcq.aat.platform.hmcts.net/privacy-policy?lng=en_GET": "ignore",
   "10104_User Agent Fuzzer_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on\u0026lng=cy_GET": "ignore",
   "10104_User Agent Fuzzer_https://pcq.aat.platform.hmcts.net/public/javascripts/cookie_bundle.js_GET": "ignore",
+  "10104_User Agent Fuzzer_https://pcq.aat.platform.hmcts.net/public/javascripts/cookie_bundle_v1.js_GET": "ignore",
   "10096_Timestamp Disclosure - Unix_https://pcq.aat.platform.hmcts.net/offline_GET": "ignore",
   "10096_Timestamp Disclosure - Unix_https://pcq.aat.platform.hmcts.net/assets/images/favicon.ico_GET": "ignore",
   "10096_Timestamp Disclosure - Unix_https://pcq.aat.platform.hmcts.net/public/javascripts/govuk-frontend/govuk/all.js_GET": "ignore",
@@ -422,6 +423,7 @@
   "40025_Proxy Disclosure_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on_GET" : "ignore",
   "40025_Proxy Disclosure_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on\u0026lng=en_GET" : "ignore",
   "40025_Proxy Disclosure_https://pcq.aat.platform.hmcts.net/public/javascripts/cookie_bundle.js_GET" : "ignore",
+  "40025_Proxy Disclosure_https://pcq.aat.platform.hmcts.net/public/javascripts/cookie_bundle_v1.js_GET" : "ignore",
   "10055_CSP: Notices_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on_GET" : "ignore",
   "10055_CSP: Notices_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on\u0026lng=cy_GET" : "ignore",
   "10055_CSP: Notices_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on\u0026lng=en_GET" : "ignore",
@@ -435,6 +437,7 @@
   "90027_Cookie Slack Detector_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on_GET" : "ignore",
   "90027_Cookie Slack Detector_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on\u0026lng=en_GET" : "ignore",
   "90027_Cookie Slack Detector_https://pcq.aat.platform.hmcts.net/public/javascripts/cookie_bundle.js_GET" : "ignore",
+  "90027_Cookie Slack Detector_https://pcq.aat.platform.hmcts.net/public/javascripts/cookie_bundle_v1.js_GET" : "ignore",
   "10109_Modern Web Application_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on_GET" : "ignore",
   "10109_Modern Web Application_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on\u0026lng=en_GET" : "ignore",
   "10109_Modern Web Application_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on\u0026lng=cy_GET" : "ignore",
@@ -443,6 +446,7 @@
   "10096_Timestamp Disclosure - Unix_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on\u0026lng=cy_GET" : "ignore",
   "10096_Timestamp Disclosure - Unix_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on\u0026lng=en_GET" : "ignore",
   "10027_Information Disclosure - Suspicious Comments_https://pcq.aat.platform.hmcts.net/public/javascripts/cookie_bundle.js_GET" : "ignore",
+  "10027_Information Disclosure - Suspicious Comments_https://pcq.aat.platform.hmcts.net/public/javascripts/cookie_bundle_v1.js_GET" : "ignore",
   "10104_User Agent Fuzzer_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on_GET" : "ignore",
   "10104_User Agent Fuzzer_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on\u0026lng=en_GET" : "ignore",
   "10031_User Controllable HTML Element Attribute (Potential XSS)_https://pcq.aat.platform.hmcts.net/cookies?analytics=on\u0026apm=on_GET" : "ignore",
@@ -453,5 +457,6 @@
   "40025_Proxy Disclosure_https://pcq.aat.platform.hmcts.net/cookies?analytics=on&apm=on&lng=cy_GET": "ignore",
   "90027_Cookie Slack Detector_https://pcq.aat.platform.hmcts.net/cookies?analytics=on&apm=on&lng=cy_GET": "ignore",
   "10096_Timestamp Disclosure - Unix_https://pcq.aat.platform.hmcts.net/public/javascripts/cookie_bundle.js_GET" : "ignore",
+  "10096_Timestamp Disclosure - Unix_https://pcq.aat.platform.hmcts.net/public/javascripts/cookie_bundle_v1.js_GET" : "ignore",
   "40022_SQL Injection - PostgreSQL - Time Based_https://pcq.aat.platform.hmcts.net/offline?lng=en_GET" : "ignore"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protected-characteristics-frontend",
   "description": "Protected Characteristics web app",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "license": "MIT",
   "engines": {
     "node": ">=14.18.1"


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/PCQ-1420

### Change description ###
Added fingerprints to audit.json to suppress cookie_bundle_v1 OWASP Zaproxy alerts.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```