### PR TITLE
PCQ-2021 defer using appInsight after start

### DIFF
--- a/app/components/app-insights.js
+++ b/app/components/app-insights.js
@@ -22,9 +22,13 @@ exports.initAppInsights = function initAppInsights() {
             .setSendLiveMetrics(true)
             .setAutoCollectConsole(true, true)
             .start();
+        
         client = appInsights.defaultClient;
-        client.context.tags[appInsights.defaultClient.context.keys.cloudRole] = 'pcq-frontend';
-        client.trackTrace({message: 'App insights activated'});
+        setImmediate(() => {
+            client.context.tags[client.context.keys.cloudRole] = 'pcq-frontend';
+            client.trackTrace({message: 'App insights activated' });
+        });
+        
     } else {
         client = null;
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protected-characteristics-frontend",
   "description": "Protected Characteristics web app",
-  "version": "1.2.212",
+  "version": "1.2.213",
   "license": "MIT",
   "engines": {
     "node": ">=14.18.1"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-2021


### Change description ###
Defer the use of application Insight after start to set up other things


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```