### PR TITLE
Re-onboard CVE dashboard ingestion

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,7 +1,7 @@
 #!groovy
 import uk.gov.hmcts.contino.GithubAPI
 
-@Library("Infrastructure@2.4.4")
+@Library("Infrastructure@cve-dashboard")
 
 def type = "nodejs"
 def product = "pcq"
@@ -24,6 +24,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 }
 
 withPipeline(type, product, component) {
+  enableCveDashboardIngestion()
 
   afterAlways('build') {
     sh 'yarn setup'


### PR DESCRIPTION
## Summary
- pin the shared Jenkins library to cve-dashboard, now based on version 2.4.9
- enable CVE dashboard ingestion

## Testing
- Jenkinsfile-only configuration change